### PR TITLE
User Serial Port Name

### DIFF
--- a/Makefile.tpl
+++ b/Makefile.tpl
@@ -53,7 +53,7 @@ F_CPU = ___VARIABLE_F_CPU___
 AVRDUDE_PROGRAMMER = ___VARIABLE_PROGRAMMER___
 
 # com1 = serial port. Use lpt1 to connect to parallel port.
-AVRDUDE_PORT = /dev/cu.usbmodemfd121    # programmer connected to serial device
+AVRDUDE_PORT = /dev/___VARIABLE_SERIAL_PORT___    # programmer connected to serial device
 
 # Output format. (can be srec, ihex, binary)
 FORMAT = ihex

--- a/TemplateInfo.plist.tpl
+++ b/TemplateInfo.plist.tpl
@@ -198,6 +198,23 @@
 				@end@
 			</dict>
 		</dict>
+		
+		<dict>
+			<key>Default</key>
+			<string>cu.usbmodem*</string>
+			<key>Description</key>
+			<string>Serial Port (for serial programmer)</string>
+			<key>Identifier</key>
+			<string>SERIAL_PORT</string>
+			<key>Name</key>
+			<string>Serial Port</string>
+			<key>SortOrder</key>
+			<integer>3</integer>
+			<key>Required</key>
+        	<true/>
+			<key>Type</key>
+			<string>text</string>
+		</dict>
 
 		<dict>
 			<key>Default</key>
@@ -209,7 +226,7 @@
 			<key>Name</key>
 			<string>Frequency</string>
 			<key>SortOrder</key>
-			<integer>3</integer>
+			<integer>4</integer>
 			<key>Required</key>
         	<true/>
 			<key>Type</key>


### PR DESCRIPTION
Fixes a bug where the user's serial port may not be the same as hardcoded value, allows the serial port to be set as a variable on project creation and defaults to cu.usbmodem*

Sorry to spam up your pull requests!